### PR TITLE
Improved enemy navigation

### DIFF
--- a/src/snack_attack.py
+++ b/src/snack_attack.py
@@ -342,6 +342,7 @@ while running:
     elif rungame and not paused:
         # Get game time delta for determining whether to move sprites. Cap at 1000 fps
         game_dt = game_time.tick(1000) / 1000
+        # game_dt = 1/1000 (used during debugging)
 
         # Get alive enemies
         alive_corns = [corn for corn in corns if not corn.is_destroyed()]


### PR DESCRIPTION
Refactored the logic for enemy navigation to avoid instances of unnecessary backtracking, which previously had the appearance of "bouncing" back and forth. The logic now correctly points the enemy in the direction of the player if they can face that direction without getting stuck, otherwise it picks a random direction from either the current direction or two orthogonal directions. At last resort, the reverse direction is used. If there is no possible direction, the direction is set to 0, 0. 

Other pathfinding algorithms like depth-first-search, breadth-first search, and A* were considered, but deemed less than ideal for this application due to the desired "random" behavior of the enemies, without backtracking along previously explored paths. 

