### PR TITLE
Changed repeated level behavior and fixed enemy spawn bug

### DIFF
--- a/src/asset/sprite.py
+++ b/src/asset/sprite.py
@@ -23,6 +23,7 @@ class Sprite:
         self.move_dist = 0
         self.facing = "right"
         self.spawn = False
+        self.destroyed = False
         self._initialize_attributes()
 
     # Initialization of more attributes
@@ -31,7 +32,6 @@ class Sprite:
         self.path_rect = define_rect(self.center_position, self.path_width)
         self.rotation_angle = 0  # + counterclockwise
         self.mirror = False
-        self.destroyed = False
         self.direction = (0, 0)
         self.desired_direction = ()
         self.motion_vector = (0, 0)
@@ -402,3 +402,7 @@ class Sprite:
     # Set motion vector
     def set_motion_vector(self, x_direction, y_direction):
         self.motion_vector = (x_direction, y_direction)
+
+    # Return direction
+    def get_direction(self):
+        return self.direction


### PR DESCRIPTION
Upon reaching the final level in the levels folder, the repeated iterations now use a frantic level speed with a pre-defined number of enemies (2 corn, 4 tomatoes, 4 pumpkins). This gives repeated levels a fresh experience, rather than reverting to the original slow speeds. The level folder name is displayed in red, with the suffix "(reprise)". The displayed level folder name is also now capped at 8 characters.

Also identified and fixed a bug where enemy spawn quantity was not tracked properly if enemies were destroyed before the final enemy spawned. This could result in fewer enemies spawning than should spawn, or the exit door not being drawn (items note being deleted) once all enemies were destroyed.

With the new control schemes which only move the player when a key is pressed, also identified a bug where the player would not fully enter the exit during the animation. Therefore, set the direction to the last direction chosen before stopping.

Changed the hotkeys for control swap and level skip, since these were previously next to each other. It is now harder to hit the other by mistake.