### PR TITLE
Added erase feature to level editor

### DIFF
--- a/src/builder/input.py
+++ b/src/builder/input.py
@@ -40,9 +40,12 @@ def process_input(
             flags.mouse_left_held = True
         elif event.button == 3:  # Right mouse button
             flags.mouse_right_click = True
+            flags.mouse_right_held = True
     elif event.type == pygame.MOUSEBUTTONUP:
         if event.button == 1:  # Left mouse button
             flags.mouse_left_held = False
+        elif event.button == 3:  # Right mouse button
+            flags.mouse_right_held = False
     elif event.type == pygame.KEYDOWN:
         if flags.maze_draw and event.key in [
             pygame.K_UP,
@@ -75,6 +78,8 @@ def process_input(
                 enemy_index,
                 asset_defs,
             )
+        elif event.key == pygame.K_x and flags.maze_draw:
+            flags.x_pressed = True
         elif event.key == pygame.K_w and flags.maze_draw:
             maze_color_index = change_maze_color(
                 screen,

--- a/src/builder/start.py
+++ b/src/builder/start.py
@@ -190,6 +190,8 @@ class Flags:
     def __init__(self):
         self.running = True
         self.mouse_left_held = False
+        self.mouse_right_held = False
         self.mouse_right_click = False
         self.arrow_pressed = False
         self.maze_draw = True
+        self.x_pressed = True

--- a/src/level_builder.py
+++ b/src/level_builder.py
@@ -1,23 +1,6 @@
-import os
 import pygame
-import time
-import tkinter as tk
-from tkinter import messagebox, filedialog
 from settings import config as cfg
-from rect.utils import define_rect, shift_rect_to_divisible_pos
-from rect.draw import draw_square, draw_asset, draw_maze
-from grid.utils import invert_maze_to_grid, grid_space
-from fileio.load import import_image_dir
-from fileio.export import (
-    export_path_coords_to_csv,
-    export_asset_coords_to_csv,
-    export_metadata,
-    move_files,
-)
-from path.utils import (
-    rect_within_boundary,
-    rect_gives_uniform_path,
-)
+from rect.draw import draw_maze
 from builder.start import (
     builder_init,
     Flags,
@@ -27,7 +10,7 @@ from builder.start import (
     draw_speed_enemy_text,
 )
 from builder.input import process_input
-from builder.draw import draw_path, undo_path_rect, undo_asset_placement
+from builder.draw import draw_path, undo_path_rect, erase_path, undo_asset_placement
 
 # Initialize level builder
 (
@@ -165,7 +148,7 @@ while flags.running:
             arrow_index,
         )
     # Undo last path draw
-    elif flags.mouse_right_click and len(chosen_coords) > 0 and flags.maze_draw:
+    elif flags.x_pressed and len(chosen_coords) > 0 and flags.maze_draw:
         flags = undo_path_rect(
             chosen_coords,
             shifted_coords_history,
@@ -175,6 +158,19 @@ while flags.running:
             screen,
             dirty_rects,
             flags,
+        )
+    # Erase path at mouse location
+    elif flags.mouse_right_held and len(chosen_coords) > 0 and flags.maze_draw:
+        erase_path(
+            block_width,
+            min_block_spacing,
+            image_boundary,
+            shifted_coords_history,
+            chosen_coords,
+            maze_colors,
+            maze_color_index,
+            screen,
+            dirty_rects,
         )
     # Undo last asset drawing
     elif flags.mouse_right_click and len(asset_coords) > 0 and not flags.maze_draw:


### PR DESCRIPTION
Implemented an erase feature to the level editor. Upon right clicking on an existing coordinate in the drawn path, this position will be erased from the maze if the resulting path is still compliant with the edge diagonal check. This required refactoring the rect_gives_uniform_path function to allow for the specified Rect to be None, such that the entire path is inspected instead of just a subset around the specified Rect.

Changed the undo button for maze drawing to X. During asset placement, right click is still used for undoing the last operation.