### PR TITLE
Added maze load feature and visual aid for erasing

### DIFF
--- a/src/builder/draw.py
+++ b/src/builder/draw.py
@@ -111,14 +111,7 @@ def draw_path(
     flags.arrow_pressed = False
 
     # Coarsen inputs prior to checking maze grid to optimize runtime
-    coords_scaled = []
-    for coord in chosen_coords:
-        coords_scaled.append(
-            (
-                int((coord[0] - cfg.DRAW_IMAGE_X - image_boundary) / cfg.SCALE_FACTOR),
-                int((coord[1] - cfg.DRAW_IMAGE_Y - image_boundary) / cfg.SCALE_FACTOR),
-            )
-        )
+    coords_scaled = scale_coords(chosen_coords, image_boundary)
     new_center = (
         int((my_rect.center[0] - cfg.DRAW_IMAGE_X - image_boundary) / cfg.SCALE_FACTOR),
         int((my_rect.center[1] - cfg.DRAW_IMAGE_Y - image_boundary) / cfg.SCALE_FACTOR),
@@ -166,6 +159,7 @@ def erase_and_redraw(
     screen,
     dirty_rects,
     chosen_coords,
+    dot_color,
 ):
     # Draw a block overtop the old coordinate
     my_rect = define_rect(cur_coord, block_width)
@@ -177,6 +171,12 @@ def erase_and_redraw(
         temp_rect = define_rect(coord, block_width)
         if temp_rect.colliderect(my_rect):
             draw_square(temp_rect, screen, cfg.COLORS["black"], dirty_rects)
+
+    # Draw dots to help show path if color specified
+    if dot_color:
+        for coord in chosen_coords:
+            temp_rect = define_rect(coord, int(block_width / 12))
+            draw_square(temp_rect, screen, dot_color, dirty_rects)
 
 
 # Function to erase path at current mouse location
@@ -207,20 +207,7 @@ def erase_path(
         temp_coords = chosen_coords.copy()
         temp_coords.remove(my_rect.center)
         # Coarsen inputs prior to checking maze grid to optimize runtime
-        coords_scaled = []
-        for coord in temp_coords:
-            coords_scaled.append(
-                (
-                    int(
-                        (coord[0] - cfg.DRAW_IMAGE_X - image_boundary)
-                        / cfg.SCALE_FACTOR
-                    ),
-                    int(
-                        (coord[1] - cfg.DRAW_IMAGE_Y - image_boundary)
-                        / cfg.SCALE_FACTOR
-                    ),
-                )
-            )
+        coords_scaled = scale_coords(temp_coords, image_boundary)
         if rect_gives_uniform_path(
             coords_scaled,
             None,
@@ -243,6 +230,7 @@ def erase_path(
                 screen,
                 dirty_rects,
                 chosen_coords,
+                cfg.COLORS["white"],
             )
 
 
@@ -271,6 +259,7 @@ def undo_path_rect(
         screen,
         dirty_rects,
         chosen_coords,
+        None,
     )
 
     # Reset flag for right click
@@ -300,3 +289,16 @@ def undo_asset_placement(
     flags.mouse_right_click = False
 
     return flags
+
+
+# Function to scale coordinates
+def scale_coords(coords, image_boundary):
+    coords_scaled = []
+    for coord in coords:
+        coords_scaled.append(
+            (
+                int((coord[0] - cfg.DRAW_IMAGE_X - image_boundary) / cfg.SCALE_FACTOR),
+                int((coord[1] - cfg.DRAW_IMAGE_Y - image_boundary) / cfg.SCALE_FACTOR),
+            )
+        )
+    return coords_scaled

--- a/src/builder/input.py
+++ b/src/builder/input.py
@@ -1,4 +1,5 @@
 import pygame
+from settings import config as cfg
 from builder.action import (
     export_maze_files,
     change_maze_color,
@@ -6,7 +7,9 @@ from builder.action import (
     cycle_enemy_quantity,
     init_asset_placement,
     assign_asset_loc,
+    import_maze_from_file,
 )
+from rect.draw import draw_maze
 
 
 # Function to handle inputs for level builder
@@ -30,6 +33,7 @@ def process_input(
     maze_color_index,
     asset_letters,
     asset_defs,
+    shifted_coords_history,
 ):
     current_arrow = None
     flags.arrow_pressed = False
@@ -46,6 +50,31 @@ def process_input(
             flags.mouse_left_held = False
         elif event.button == 3:  # Right mouse button
             flags.mouse_right_held = False
+            if flags.draw_dots:
+                # Re-draw maze without center dots
+                chosen_coords_draw = [
+                    (
+                        x - cfg.DRAW_IMAGE_X - image_boundary,
+                        y - cfg.DRAW_IMAGE_Y - image_boundary,
+                    )
+                    for x, y in chosen_coords
+                ]
+                draw_maze(
+                    cfg.DRAW_IMAGE_X + image_boundary,
+                    cfg.DRAW_IMAGE_Y + image_boundary,
+                    0,
+                    maze_width,
+                    maze_height,
+                    int(block_width),
+                    maze_colors[maze_color_index],
+                    cfg.COLORS["black"],
+                    chosen_coords_draw,
+                    screen,
+                    0,
+                    None,
+                    None,
+                )
+                flags.draw_dots = False
     elif event.type == pygame.KEYDOWN:
         if flags.maze_draw and event.key in [
             pygame.K_UP,
@@ -105,6 +134,12 @@ def process_input(
             enemy_index = cycle_enemy_quantity(
                 "pumpkin", enemy_index, enemy_quantity, screen, fonts, dirty_rects
             )
+        elif event.key == pygame.K_ESCAPE and flags.maze_draw:
+            chosen_coords, shifted_coords_history, maze_color_index = (
+                import_maze_from_file(
+                    image_boundary, maze_width, maze_height, block_width, screen
+                )
+            )
         elif event.key == pygame.K_a:
             asset_letters, asset_defs = init_asset_placement(
                 chosen_coords,
@@ -139,4 +174,6 @@ def process_input(
         maze_color_index,
         asset_letters,
         asset_defs,
+        shifted_coords_history,
+        chosen_coords,
     )

--- a/src/builder/start.py
+++ b/src/builder/start.py
@@ -103,6 +103,10 @@ def print_draw_instructions(fonts, screen):
         loc = cfg.TEXT_LOC["maze_draw"]
         screen.blit(text_surface, (loc[0], loc[1] + row * loc[2]))
 
+    text_surface = fonts["normal"].render(cfg.LOAD_TEXT, True, cfg.COLORS["black"])
+    loc = cfg.TEXT_LOC["maze_load"]
+    screen.blit(text_surface, (loc[0], loc[1]))
+
 
 # Function to load enemy images and max quantities
 def init_enemies():
@@ -195,3 +199,4 @@ class Flags:
         self.arrow_pressed = False
         self.maze_draw = True
         self.x_pressed = True
+        self.draw_dots = False

--- a/src/level_builder.py
+++ b/src/level_builder.py
@@ -50,6 +50,7 @@ draw_maze(
     screen,
     0,
     None,
+    None,
 )
 draw_maze(
     cfg.DRAW_IMAGE_X + image_boundary,
@@ -64,6 +65,7 @@ draw_maze(
     screen,
     0,
     None,
+    None,
 )
 
 # Display instruction text
@@ -71,7 +73,6 @@ print_draw_instructions(fonts, screen)
 
 # Initialize enemy images and quantities
 enemy_quantity, enemy_index, images, enemy_image = init_enemies()
-
 
 # Draw enemy sprites
 draw_enemies(screen, enemy_image["corn"], enemy_image["tomato"], enemy_image["pumpkin"])
@@ -103,6 +104,8 @@ while flags.running:
             maze_color_index,
             asset_letters,
             asset_defs,
+            shifted_coords_history,
+            chosen_coords,
         ) = process_input(
             event,
             flags,
@@ -123,6 +126,7 @@ while flags.running:
             maze_color_index,
             asset_letters,
             asset_defs,
+            shifted_coords_history,
         )
 
     # Limit input collection to 60 hz to limit CPU overhead
@@ -161,6 +165,34 @@ while flags.running:
         )
     # Erase path at mouse location
     elif flags.mouse_right_held and len(chosen_coords) > 0 and flags.maze_draw:
+        if not flags.draw_dots:
+            # Reveal center of coordinates using dots to make erasing easier
+            chosen_coords_draw = [
+                (
+                    x - cfg.DRAW_IMAGE_X - image_boundary,
+                    y - cfg.DRAW_IMAGE_Y - image_boundary,
+                )
+                for x, y in chosen_coords
+            ]
+
+            draw_maze(
+                cfg.DRAW_IMAGE_X + image_boundary,
+                cfg.DRAW_IMAGE_Y + image_boundary,
+                0,
+                maze_width,
+                maze_height,
+                int(block_width),
+                maze_colors[maze_color_index],
+                cfg.COLORS["black"],
+                chosen_coords_draw,
+                screen,
+                0,
+                None,
+                cfg.COLORS["white"],
+            )
+
+            flags.draw_dots = True
+
         erase_path(
             block_width,
             min_block_spacing,

--- a/src/path/utils.py
+++ b/src/path/utils.py
@@ -100,10 +100,10 @@ def diag_direction_legal(
     found_wall = False
     while not found_wall and not found_boundary:
         if (
-            row - diag_width < 0
-            or col - diag_width < 0
-            or row + diag_width == maze_height
-            or col + diag_width == maze_width
+            row + diag_width * diag_direction[1] < 0
+            or col + diag_width * diag_direction[0] < 0
+            or row + diag_width * diag_direction[1] == maze_height
+            or col + diag_width * diag_direction[0] == maze_width
         ):
             found_boundary = True
         elif (

--- a/src/rect/draw.py
+++ b/src/rect/draw.py
@@ -108,6 +108,7 @@ def draw_maze(
     screen,
     time_delay,
     quit_key,
+    dot_color,
 ):
     outer_rect = pygame.Rect(
         draw_image_x,
@@ -147,4 +148,13 @@ def draw_maze(
 
         if exit_key_selected:
             break
+    # Overlay dots to show path if color specified
+    if dot_color:
+        for coord in path_coords:
+            shifted_coord = (
+                coord[0] + draw_image_x + image_boundary,
+                coord[1] + draw_image_x + image_boundary,
+            )
+            my_rect = define_rect(shifted_coord, int(block_width / 12))
+            draw_square(my_rect, screen, dot_color, dirty_rects)
     return exit_key_selected

--- a/src/settings/config.py
+++ b/src/settings/config.py
@@ -69,6 +69,9 @@ DRAW_STRINGS = [
     "L to cycle # pumpkin enemies",
 ]
 
+# Load maze instruction text
+LOAD_TEXT = "Press Escape to import an existing maze"
+
 # Level asset placement instruction text
 ASSET_STRINGS = [
     "Key (see list below) to place",
@@ -169,6 +172,7 @@ TEXT_LOC["level_speed"] = (1455, 350)
 TEXT_LOC["corn"] = (1168, 760)
 TEXT_LOC["tomato"] = (1306, 760)
 TEXT_LOC["pumpkin"] = (1448, 760)
+TEXT_LOC["maze_load"] = (275, 850)
 # Maze asset placement text
 TEXT_LOC["place_assets_row_1"] = (1120, 100, 40)
 TEXT_LOC["place_assets"] = (1120, 100, 50)
@@ -207,6 +211,7 @@ WHITE_RECTS["speed"] = (1450, 350, 400, 100)
 WHITE_RECTS["corn"] = (1170, 780, BLOCK_WIDTH * SCALE_FACTOR)
 WHITE_RECTS["tomato"] = (1310, 780, BLOCK_WIDTH * SCALE_FACTOR)
 WHITE_RECTS["pumpkin"] = (1450, 780, BLOCK_WIDTH * SCALE_FACTOR)
+WHITE_RECTS["maze_load"] = (250, 850, 700, 100)
 
 
 # Set game tick speed to such that movement calculation is no more than one

--- a/src/snack_attack.py
+++ b/src/snack_attack.py
@@ -140,6 +140,7 @@ while flags.running:
             screen,
             0.003,
             pygame.K_F10,
+            None,
         )
 
         # Create maze grid based on fidelity

--- a/src/title/intro.py
+++ b/src/title/intro.py
@@ -218,6 +218,7 @@ def run_title_screen(
                 screen,
                 0,
                 None,
+                None,
             )
 
             # Print game info and instructions


### PR DESCRIPTION
During the maze draw phase of the level editor, added an option to import the csv file with a prior maze's path coordinates. This overwrites the current maze in progress and loads the chosen maze. 

Also addressed a bug in the refactored logic for the diagonal checks, where incorrect non-compliances were being triggered due to a false boundary detection. 

To aid the erase feature, added a dot overlay to indicate the location of the chosen coordinates. This is activated when holding the right mouse button for erasing, and the maze path returns to a normal appearance when releasing the right mouse button.