### PR TITLE
Fixed first asset placement bug by increasing tick rate

### DIFF
--- a/src/level_builder.py
+++ b/src/level_builder.py
@@ -129,8 +129,12 @@ while flags.running:
             shifted_coords_history,
         )
 
-    # Limit input collection to 60 hz to limit CPU overhead
-    clock.tick(60)
+    if flags.maze_draw:
+        # Limit maze draw input collection to 60 hz to limit CPU overhead
+        clock.tick(60)
+    else:
+        # For smoother asset placement, allow higher tick rate
+        clock.tick(360)
 
     # Check if an arrow key was pressed, or if left mouse is currently held
     # down (outside of event loop) If so, draw a new square at that location,


### PR DESCRIPTION
A bug existed where the first asset would immediately disappear upon placement. This was fixed by changing the input tick rate to 360 hz for asset placement, retaining 60 hz for maze drawing to limit CPU overhead.