### PR TITLE
Fixed bug that allowed repeated hotkey press for asset mode

### DIFF
--- a/src/builder/input.py
+++ b/src/builder/input.py
@@ -140,7 +140,7 @@ def process_input(
                     image_boundary, maze_width, maze_height, block_width, screen
                 )
             )
-        elif event.key == pygame.K_a:
+        elif event.key == pygame.K_a and flags.maze_draw:
             asset_letters, asset_defs = init_asset_placement(
                 chosen_coords,
                 image_boundary,


### PR DESCRIPTION
Fixed a bug where the user could repeatedly press the "A" hotkey for initializing the asset placement mode, even after it had already been pressed. The behavior could inadvertently result in overwriting the "no assets" screenshot of the level. Now this hotkey will only result in action when the user is in maze draw mode.