### PR TITLE
Enemy pathfinding with BFS and sprite collision tweaks

### DIFF
--- a/src/asset/player.py
+++ b/src/asset/player.py
@@ -5,10 +5,10 @@ from asset.sprite import Sprite
 # Class to define a sprite and its methods
 class Player(Sprite):
     def __init__(
-        self, name, image, center_position, speed, can_rotate, hitbox_width, path_width
+        self, name, image, center_position, speed, can_rotate, hitbox_width, path_width, rotate_image
     ):
         super().__init__(
-            name, image, center_position, speed, can_rotate, hitbox_width, path_width
+            name, image, center_position, speed, can_rotate, hitbox_width, path_width, rotate_image
         )
 
     # Assign direction based on user input

--- a/src/builder/start.py
+++ b/src/builder/start.py
@@ -131,7 +131,7 @@ def init_enemies():
             ),
         )
         # Make teal the transparent color
-        images[image].set_colorkey(cfg.COLORS["teal"])
+        images[image].set_colorkey(cfg.COLORS["replace_teal"])
 
     enemy_image = {}
     enemy_image["corn"] = images["corn"]

--- a/src/fileio/load.py
+++ b/src/fileio/load.py
@@ -43,6 +43,7 @@ def get_levels(directory_path):
             asset_filepath = ""
             metadata_filepath = ""
             path_filepath = ""
+            sprite_colors_filepath = ""
             screenshot_filepath = ""
             for filename in os.listdir(map_path):
                 if filename.lower().endswith("asset_coordinates.csv"):
@@ -51,6 +52,8 @@ def get_levels(directory_path):
                     metadata_filepath = os.path.join(map_path, filename)
                 elif filename.lower().endswith("path_coordinates.csv"):
                     path_filepath = os.path.join(map_path, filename)
+                elif filename.lower().endswith("sprite_colors.csv"):
+                    sprite_colors_filepath = os.path.join(map_path, filename)
                 elif filename.lower().endswith("screenshot.png"):
                     screenshot_filepath = os.path.join(map_path, filename)
             if asset_filepath and metadata_filepath and path_filepath:
@@ -59,6 +62,7 @@ def get_levels(directory_path):
                         "assets": asset_filepath,
                         "metadata": metadata_filepath,
                         "path": path_filepath,
+                        "sprite_colors": sprite_colors_filepath,
                         "screenshot": screenshot_filepath,
                         "folder": folder,
                     }

--- a/src/game/assets.py
+++ b/src/game/assets.py
@@ -15,8 +15,9 @@ def init_items(asset_coord, images, block_width, maze_factor):
                 asset_coord.get(key),
                 0,
                 False,
-                int(block_width / (maze_factor * 6)),
+                int(block_width / (maze_factor * 4)),
                 int(block_width / maze_factor),
+                None,
             )
     return items
 
@@ -30,6 +31,7 @@ def init_enemies(
     pixels_per_second,
     hitbox_size,
     path_size,
+    rotate_image,
     is_invincible,
 ):
     enemy_list = []
@@ -43,6 +45,7 @@ def init_enemies(
                 False,
                 hitbox_size,
                 path_size,
+                rotate_image,
                 is_invincible,
             )
         )

--- a/src/game/start.py
+++ b/src/game/start.py
@@ -114,7 +114,7 @@ def load_resources():
             ),
         )
         # Make teal the transparent color
-        images[image].set_colorkey(cfg.COLORS["teal"])
+        images[image].set_colorkey(cfg.COLORS["replace_teal"])
 
     # Get sound effects
     sounds = import_sound_dir(cfg.DIRS["sounds"])

--- a/src/path/pathfind.py
+++ b/src/path/pathfind.py
@@ -1,0 +1,71 @@
+from collections import deque
+
+
+# Function to create graph from the chosen coordinates, representing as an adjacency list
+def create_graph(coords, scale_factor, dist_threshold):
+    scaled_coords = [
+        tuple(int(element / scale_factor) for element in coord) for coord in coords
+    ]
+    graph = {point: [] for point in scaled_coords}
+
+    num_points = len(scaled_coords)
+    for i in range(num_points):
+        for j in range(i + 1, num_points):
+            p1 = (scaled_coords[i][0], scaled_coords[i][1])
+            p2 = (scaled_coords[j][0], scaled_coords[j][1])
+
+            # Check if points are within threshold on x or y axes
+            if (abs(p1[0] - p2[0]) <= dist_threshold and p1[1] == p2[1]) or (
+                abs(p1[1] - p2[1]) <= dist_threshold and p1[0] == p2[0]
+            ):
+                graph[p1].append(p2)
+                graph[p2].append(p1)
+
+    return graph, scaled_coords
+
+
+# Function to create flow field starting at goal coordinate using breadth first search
+def create_flow_field(graph, all_points, goal_coordinate):
+    # Integration field stores shortest distance from each point to the goal
+    integration_field = {point: float("inf") for point in all_points}
+    integration_field[goal_coordinate] = 0
+
+    queue = deque([goal_coordinate])
+
+    while queue:
+        current_node = queue.popleft()
+        current_distance = integration_field[current_node]
+
+        for neighbor in graph[current_node]:
+            # If a shorter path to a neighbor is found, update it and add to queue
+            if integration_field[neighbor] > current_distance + 1:
+                integration_field[neighbor] = current_distance + 1
+                queue.append(neighbor)
+
+    # Generate flow field vectors by finding neighbor with lowest distance for each point
+    flow_field = {}
+    for point in all_points:
+        if point == goal_coordinate:
+            flow_field[point] = (0, 0)
+            continue
+
+        min_distance = float("inf")
+        best_neighbor = None
+
+        # Find neighbor with minimum distance to the goal
+        for neighbor in graph[point]:
+            if integration_field[neighbor] < min_distance:
+                min_distance = integration_field[neighbor]
+                best_neighbor = neighbor
+
+        # If a path exists, set the vector
+        if best_neighbor:
+            x_dir = best_neighbor[0] - point[0]
+            x_dir = 1 if x_dir > 0 else (-1 if x_dir < 0 else 0)
+            y_dir = best_neighbor[1] - point[1]
+            y_dir = 1 if y_dir > 0 else (-1 if y_dir < 0 else 0)
+            flow_field[point] = (x_dir, y_dir)
+        else:
+            flow_field[point] = None  # Unreachable point
+
+    return flow_field

--- a/src/rect/draw.py
+++ b/src/rect/draw.py
@@ -179,9 +179,12 @@ def draw_maze(
                 if event.key == quit_key:
                     quit_key_down = True
             if event.type == pygame.KEYUP:
-                if event.key == quit_key and quit_key_down:
-                    exit_key_selected = True
-                    break
+                try:
+                    if event.key == quit_key and quit_key_down:
+                        exit_key_selected = True
+                        break
+                except:
+                    pass
 
         if exit_key_selected:
             break

--- a/src/settings/config.py
+++ b/src/settings/config.py
@@ -17,8 +17,8 @@ FILES["settings"] = "config.csv"
 FILES["grid"] = "level_grid.txt"
 
 # User config, maze fidelity, screen dimensions
-MAZE_FIDELITY_OPTS = ["coarse", "normal", "fine"]
-MAZE_FIDELITY_FACTORS = [4, 2, 1]
+MAZE_FIDELITY_OPTS = ["very coarse", "coarse", "normal", "fine"]
+MAZE_FIDELITY_FACTORS = [8, 4, 2, 1]
 WIDTH, HEIGHT = (1600, 900)
 
 # Define maze properties
@@ -40,7 +40,8 @@ MAX_PUMPKIN = 4
 
 # Define colors
 COLORS = {}
-COLORS["teal"] = (0, 168, 168)
+COLORS["teal"] = (0, 167, 167)
+COLORS["replace_teal"] = (0, 168, 168)
 COLORS["yellow"] = (255, 255, 0)
 COLORS["orange"] = (255, 128, 0)
 COLORS["green"] = (0, 255, 0)
@@ -48,7 +49,9 @@ COLORS["dkgreen"] = (0, 102, 0)
 COLORS["purple"] = (128, 0, 128)
 COLORS["magenta"] = (253, 61, 181)
 COLORS["red"] = (255, 0, 0)
+COLORS["replace_red"] = (100, 0, 0)
 COLORS["blue"] = (0, 0, 255)
+COLORS["replace_blue"] = (0, 0, 100)
 COLORS["gray"] = (128, 128, 128)
 COLORS["white"] = (255, 255, 255)
 COLORS["black"] = (0, 0, 0)
@@ -287,6 +290,9 @@ IMAGE_SERIES["door"] = (
     "door_open_04",
 )
 
+# Flag for whether to animate the exit closing on top of player
+CLOSE_EXIT_OVERTOP = True
+
 # Delays for animations
 DELAYS = {}
 DELAYS["corn"] = [0.1, 0.15, 0.2, 0.25, 0.3]
@@ -313,7 +319,7 @@ LIVES_DEFAULT = 5
 # Title text
 TITLE_TEXT = "Snack Attack"
 AUTHOR_TEXT = "Programmed in Python by Tim Roble"
-VERSION_TEXT = "Version 1.1.1, September 2025"
+VERSION_TEXT = "Version 1.2.0, September 2025"
 PROCEED_TEXT = "Press Spacebar to Start Game"
 
 # Animation info strings

--- a/src/title/intro.py
+++ b/src/title/intro.py
@@ -274,6 +274,7 @@ def run_title_screen(
                 pixels_per_second,
                 int(block_width / (maze_factor * 2)),
                 int(block_width / maze_factor),
+                None,
                 False,
             )
             tomatoes = init_enemies(
@@ -284,6 +285,7 @@ def run_title_screen(
                 pixels_per_second,
                 int(block_width / (maze_factor * 2)),
                 int(block_width / maze_factor),
+                None,
                 False,
             )
             pumpkins = init_enemies(
@@ -294,6 +296,7 @@ def run_title_screen(
                 pixels_per_second,
                 int(block_width / (maze_factor * 2)),
                 int(block_width / maze_factor),
+                None,
                 True,
             )
 
@@ -326,8 +329,18 @@ def run_title_screen(
             active_enemies = [enemy for enemy in alive_enemies if enemy.can_spawn()]
 
             # Move player, projectiles, and enemies
-            flags = move_sprites(
-                None, None, active_enemies, flags, maze_grid, game_tick
+            flags, _ = move_sprites(
+                None,
+                None,
+                active_enemies,
+                flags,
+                maze_grid,
+                game_tick,
+                None,
+                None,
+                None,
+                None,
+                [],
             )
 
             # Draw item and enemy sprites


### PR DESCRIPTION
Improved enemy pathfinding by generating a flow field across the level grid with the breadth-first search algorithm. This flow field indicates what direction enemies should travel to reach a target position. It is re-calculated when the player moves to another coordinate in the level path (defined based on the maze creation). The previous pathfinding algorithm is used until the enemy can see the player with no obstructions, at which point it will continuously navigate towards the player. 

Modified enemy behavior such that items and the exit are treated as obstacles, which can help the player when they are being followed.

Added a "very coarse" option for animation speed, to help on slower PCs.

Implemented an ability to specify a rotation image, instead of performing manual image rotations. Also added code to support sprite color swaps if desired. This requires a sprite_colors.csv file in the level directory, containing a dictionary with keys "first_color" and "second_color", where these include strings for the desired colors, e.g., "red" and "blue".

